### PR TITLE
[junio]: Set default values for docker-compose and enhance .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 # Database configuration
 DB_PORT=5432
-DB_PASSWD=db.password
-DB_USER=db.user
-DB_NAME=db.name
+DB_PASSWD=password
+DB_USER=user
+DB_NAME=db

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,10 +2,10 @@ services:
   database:
     hostname: database
     image: postgres
-    env_file: .env
+    env_file: ${ENV_FILE:-.env.example}
     ports:
-      - ${DB_PORT}:5432
+      - ${DB_PORT:-5432}:5432
     environment:
-      POSTGRES_PASSWORD: ${DB_PASSWD}
-      POSTGRES_USER: ${DB_USER}
-      POSTGRES_DB: ${DB_NAME}
+      POSTGRES_PASSWORD: ${DB_PASSWD:-password}
+      POSTGRES_USER: ${DB_USER:-user}
+      POSTGRES_DB: ${DB_NAME:-db}


### PR DESCRIPTION
Fixed the issue where Docker Compose wasn't loading default values from `.env.example` as expected.
Now added default values to cover cases with no loaded environment variables. Also, cleaned up strange `db.` prefixes in `.env.example.`